### PR TITLE
codefix

### DIFF
--- a/notebooks/stitches_dev/functions/nearest_neighbor_matching.R
+++ b/notebooks/stitches_dev/functions/nearest_neighbor_matching.R
@@ -286,7 +286,8 @@ match_neighborhood <- function(target_data, archive_data, tol = 0,
            target_start_yr, target_end_yr, target_year, target_fx, target_dx,
            archive_experiment, archive_variable, archive_model, archive_ensemble,
            archive_start_yr, archive_end_yr, archive_year, archive_fx, archive_dx,
-           dist_dx, dist_fx, dist_l2) ->
+           dist_dx, dist_fx, dist_l2)  %>%
+    filter(dist_l2 <= tol) ->
     out
   
   

--- a/notebooks/stitches_dev/functions/nearest_neighbor_matching.R
+++ b/notebooks/stitches_dev/functions/nearest_neighbor_matching.R
@@ -60,7 +60,7 @@ internal_dist <- function(fx_pt, dx_pt, archivedata, tol = 0){
   }
   else {
     min_dist <- min(dist$dist_l2)
-    dist_radius <- min_dist + tol
+    dist_radius <- tol
     
     index <- which(dist$dist_l2 <= dist_radius)
   }


### PR DESCRIPTION
fix issue with matching

previously, in the case of matches where there was a distance of 0 (aka points match to themself), the tolerance in matching behaved as expected.

As written, when the code had a match with a distance > 0, the tolerance would be effectively increased by whatever the minimum distance match was. Usually, pretty close to 0 so that's why we didn't catch it. Corrected with a reenforcement now. Stupid mistake, probably mine, but it just means we're working with slightly more generous matching than we thought previously - all our findings still hold because we're getting stricter with this