### PR TITLE
Acs small runs

### DIFF
--- a/modules/paper_experiment_scenarioMIP2.py
+++ b/modules/paper_experiment_scenarioMIP2.py
@@ -28,17 +28,6 @@ OUTPUT_DIR = pkg_resources.resource_filename('stitches', 'data/created_data')
 tolerance = 0.075
 Ndraws = 1
 
-# pangeo table of ESMs for reference
-pangeo_path = pkg_resources.resource_filename('stitches', 'data/pangeo_table.csv')
-pangeo_data = pd.read_csv(pangeo_path)
-pangeo_data = pangeo_data[(pangeo_data['variable'] == 'tas') & (pangeo_data['domain'] == 'Amon') ].copy()
-
-pangeo_126_esms = pangeo_data[(pangeo_data['experiment'] == 'ssp126')].model.unique().copy()
-pangeo_126_esms.sort()
-pangeo_585_esms = pangeo_data[(pangeo_data['experiment'] == 'ssp585')].model.unique().copy()
-pangeo_585_esms.sort()
-
-
 # #############################################################################
 # Helper functions
 # #############################################################################
@@ -193,7 +182,7 @@ full_archive_data = pd.read_csv(full_archive_path)
 full_target_path = pkg_resources.resource_filename('stitches', 'data/matching_archive.csv')
 full_target_data = pd.read_csv(full_target_path)
 
-esms=['MIROC6']
+
 # for each of the esms in the experiment, subset to what we want
 # to work with and run the experiment.
 for esm in esms:
@@ -269,27 +258,6 @@ for esm in esms:
         if not target_245.empty:
             match_245_df = stitches.match_neighborhood(target_245, archive_data,
                                                        tol=tolerance)
-
-            # dat = match_245_df.drop_duplicates().copy()
-            # dat_count = dat.groupby(["target_variable", "target_experiment", "target_ensemble", "target_model",
-            #                          "target_start_yr", "target_end_yr", "target_year", "target_fx",
-            #                          "target_dx"]).size().reset_index(name='n_matches')
-            # dat_count = dat_count.sort_values(["target_year"])
-            #
-            # dat_min = dat_count.groupby(["target_variable", "target_experiment", "target_ensemble", "target_model"])[
-            #     'n_matches'].min().reset_index(name='minNumMatches')
-            # dat_prod = dat_count.groupby(["target_variable", "target_experiment", "target_ensemble", "target_model"])[
-            #     'n_matches'].prod().reset_index(name='totalNumPerms')
-            # dat_count_merge = dat_min.merge(dat_prod)
-            #
-            # out = [dat_count_merge, dat_count]
-            #
-            # x = out[1].copy()
-            # y = x[x['n_matches'] <= 7].copy() # 7 from out[0]
-            # match_245_df.merge(y, how='inner')[['target_ensemble', 'target_year',
-            #                                     'archive_experiment', 'archive_ensemble', 'archive_year',
-            #                                     'dist_l2', 'n_matches']].drop_duplicates().to_csv((OUTPUT_DIR +'/matchcheck.csv'))
-
         else:
             print('No target ssp245 data for ' + esm + '. Analysis will be skipped')
 
@@ -373,3 +341,11 @@ for esm in esms:
         print(esm + ' failed. investigate offline')
 
 # end for loop over ESMs
+
+# rp1 = pd.read_csv((OUTPUT_DIR + '/MIROC6/gridded_recipes_MIROC6_target2451.csv'))
+# rp2 = pd.read_csv((OUTPUT_DIR + '/MIROC6/gridded_recipes_MIROC6_target245.csv'))
+# pd.merge(rp1, rp2, how = 'outer')
+
+# rp1 = pd.read_csv((OUTPUT_DIR + '/MRI-ESM2-0/gridded_recipes_MRI-ESM2-0_target3701.csv'))
+# rp2 = pd.read_csv((OUTPUT_DIR + '/MRI-ESM2-0/gridded_recipes_MRI-ESM2-0_target370.csv'))
+# pd.merge(rp1, rp2, how = 'outer')

--- a/stitches/fx_match.py
+++ b/stitches/fx_match.py
@@ -164,7 +164,8 @@ def match_neighborhood(target_data, archive_data, tol=0, drop_hist_duplicates=Tr
     util.check_columns(target_data, {"start_yr", "end_yr", "fx", "dx"})
 
     # shufflle the the archive data
-    archive_data = shuffle_function(archive_data)
+    # archive_data = shuffle_function(archive_data)
+    archive_data = archive_data.reset_index(drop=True).copy()
 
     # For every entry in the target data frame find its nearest neighboor from the archive data.
     # concatenate the results into a single data frame.

--- a/stitches/fx_recepie.py
+++ b/stitches/fx_recepie.py
@@ -308,7 +308,7 @@ def permute_stitching_recipes(N_matches, matched_data, archive, optional=None, t
             one_one_match = []
             for name, group in grouped_targets:
                 if testing:
-                    one_one_match.append(group.sample(1, replace=False, random_state=stitch_ind))
+                    one_one_match.append(group.sample(1, replace=False, random_state=1))
                 else:
                     one_one_match.append(group.sample(1, replace=False))
             one_one_match = pd.concat(one_one_match)


### PR DESCRIPTION
this branch:
1. makes the selection of 5 target ensemble members in the cap5-bracketing exercise more robust (`modules/paper_experiment/scenarioMIP2.py`) and also saves off relevant comparison data explicitly in the code
2. makes reproducible mode work

selecting 5 target ensemble members is now based on selecting the numerical first 5 rather than alphabetical first 5 (so r1 comes before r10) and is done separately for ssp245 and ssp370 in case different ensemble members were completed for the different experiments