### PR TITLE
Acs gridded enriched

### DIFF
--- a/modules/paper1_enrich_ensemble.py
+++ b/modules/paper1_enrich_ensemble.py
@@ -82,13 +82,9 @@ ensemble_count = (
 archive_path = pkg_resources.resource_filename('stitches', 'data/matching_archive.csv')
 archive_data = pd.read_csv(archive_path)
 
-# # limiting to a specific model...
-# limit_to_this = 'CanESM5' # 'ACCESS-ESM1-5' # , 'MIROC-ES2L']
-# archive_data = archive_data.loc[archive_data["model"] == limit_to_this]
-# ensemble_count = ensemble_count.loc[ensemble_count["model"] == limit_to_this]
 
 # Determine the ensemble sizes
-ensemble_size = [5, 10]
+ensemble_size = [5, 10, 15, 20, 25]
 for en_size in ensemble_size:
 
     sufficient_en_count = ensemble_count.loc[ensemble_count["ensemble"] >= en_size].copy()
@@ -102,6 +98,8 @@ for en_size in ensemble_size:
     # Iterate through each model that meets the experiment requirements
     for model in model_list:
         for target_exp in ["ssp245", "ssp370"]:
+
+            print(model +" " +  target_exp + ". Archive ensemble size " + str(en_size))
 
             # Set up the base name
             base_file_name = OUTPUT_DIR + '/'+ str(en_size) + "_" + model + "_" + target_exp
@@ -178,8 +176,7 @@ for en_size in ensemble_size:
             out_1["tol"] = "0.10"
             out_13["tol"] = "0.13"
 
-            out = pd.concat([out_07,out_075
-                                , out_1, out_13])
+            out = pd.concat([out_07,out_075, out_1, out_13])
             out["experiment"] = target_exp
             out["ensemble_size"] = en_size
             fname = base_file_name + "_synthetic.csv"

--- a/modules/paper1_enrich_ensemble.py
+++ b/modules/paper1_enrich_ensemble.py
@@ -20,7 +20,11 @@ pd.set_option('display.max_columns', None)
 
 # results will be written into an `enrich_ensemble_size`  directory in the
 # stitches package `data` directory.
-OUTPUT_DIR = pkg_resources.resource_filename('stitches', 'data/enrich_ensemble_size')
+if len(archive_exps) == 2:
+    OUTPUT_DIR = pkg_resources.resource_filename('stitches', 'data/enrich_ensemble_size_bracketOnlyArchive')
+
+if len(archive_exps) == 4:
+    OUTPUT_DIR = pkg_resources.resource_filename('stitches', 'data/enrich_ensemble_size_allExpsArchive')
 
 
 # Set the seed so that it is reproducible
@@ -124,17 +128,17 @@ for en_size in ensemble_size:
             target_to_use.to_csv(fname)
 
             # Read in & save the comparison data.
-            data_path = pkg_resources.resource_filename('stitches', 'data/tas-data/' + model + "_tas.csv")
-            data = pd.read_csv(data_path)
-            data = data.loc[(data["experiment"] == target_exp) & (data["ensemble"].isin(selected_en))].copy()
-            fname = base_file_name + "_compdata.csv"
-            data.to_csv(fname)
+            # data_path = pkg_resources.resource_filename('stitches', 'data/tas-data/' + model + "_tas.csv")
+            # data = pd.read_csv(data_path)
+            # data = data.loc[(data["experiment"] == target_exp) & (data["ensemble"].isin(selected_en))].copy()
+            # fname = base_file_name + "_compdata.csv"
+            # data.to_csv(fname)
 
             data_path = pkg_resources.resource_filename('stitches', 'data/tas-data/' + model + "_tas.csv")
             data = pd.read_csv(data_path)
             data = data.loc[
                 (data["experiment"] == target_exp) & (data["ensemble"].isin(target_to_use.ensemble.unique()))].copy()
-            fname = base_file_name + "_compdata_entire_target.csv"
+            fname = base_file_name + "_compdata.csv"
             data.to_csv(fname)
 
             # Generate the recipes using the various tols.

--- a/modules/paper1_enrich_ensemble.py
+++ b/modules/paper1_enrich_ensemble.py
@@ -7,27 +7,55 @@
 # the target scenario itself as well (but not only, i.e. using the other scenarios’ members available as well)?
 # tolerances of (0.07, 0.1, 0.13)?
 
-
+# Import packages
 import stitches
 import pandas as pd
 import pkg_resources
 import random
 
+exps = ["ssp126", "ssp245", "ssp585", "ssp370"]
+archive_exps = set(['ssp126', 'ssp585'])  # set(exps)
+
+pd.set_option('display.max_columns', None)
+
+# results will be written into an `enrich_ensemble_size`  directory in the
+# stitches package `data` directory.
+OUTPUT_DIR = pkg_resources.resource_filename('stitches', 'data/enrich_ensemble_size')
+
+
 # Set the seed so that it is reproducible
 random.seed(10)
 
+# #####################################################
+# Helper functions
+# #####################################################
+# Function to remove any ensemble members from a target data frame that
+# stop before 2099, for example, ending in 2014 like some MIROC6 SSP245:
+def prep_target_data(target_df):
+    if not target_df.empty:
+        grped = target_df.groupby(['experiment', 'variable', 'ensemble', 'model'])
+        for name, group in grped:
+            df1 = group.copy()
+            # if it isn't a complete time series (defined as going to 2099 or 2100),
+            # remove it from the target data frame:
+            if max(df1.end_yr) < 2099:
+                target_df = target_df.loc[(target_df['ensemble'] != df1.ensemble.unique()[0])].copy().reset_index(
+                    drop=True)
+            del (df1)
+        del (grped)
+
+        target_df = target_df.reset_index(drop=True).copy()
+        return(target_df)
+
+# ##########################################################
 # Start by figuring out which of the models meets the criteria ~8/~10 ensemble members per scenario
 # pangeo table of ESMs for reference
 archive_path = pkg_resources.resource_filename('stitches', 'data/matching_archive.csv')
 archive_data = pd.read_csv(archive_path)
-archive_data = archive_data[archive_data['experiment'].isin({'ssp126', 'ssp245', 'ssp370', 'ssp585',
-                                         'ssp119',  'ssp534-over', 'ssp434', 'ssp460'})].copy()
-
+archive_data = archive_data[archive_data['experiment'].isin({'ssp126', 'ssp245', 'ssp370', 'ssp585'})].copy()
 
 pangeo_data = archive_data[["experiment", "ensemble", "model"]].drop_duplicates()
 
-# Subset the pangeo data frame so that we only have data for the experiments we are interested in.
-exps = ["ssp126", "ssp245", "ssp585", "ssp370"]
 
 # Subset the pangeo data so that it only include data for the models that have the experiments of
 # interest.
@@ -54,10 +82,10 @@ ensemble_count = (
 archive_path = pkg_resources.resource_filename('stitches', 'data/matching_archive.csv')
 archive_data = pd.read_csv(archive_path)
 
-# limiting to a specific model...
-limit_to_this = 'CanESM5' # 'ACCESS-ESM1-5' # , 'MIROC-ES2L']
-archive_data = archive_data.loc[archive_data["model"] == limit_to_this]
-ensemble_count = ensemble_count.loc[ensemble_count["model"] == limit_to_this]
+# # limiting to a specific model...
+# limit_to_this = 'CanESM5' # 'ACCESS-ESM1-5' # , 'MIROC-ES2L']
+# archive_data = archive_data.loc[archive_data["model"] == limit_to_this]
+# ensemble_count = ensemble_count.loc[ensemble_count["model"] == limit_to_this]
 
 # Determine the ensemble sizes
 ensemble_size = [5, 10]
@@ -76,13 +104,14 @@ for en_size in ensemble_size:
         for target_exp in ["ssp245", "ssp370"]:
 
             # Set up the base name
-            base_file_name = pkg_resources.resource_filename('stitches', '/enrich_ensemble_size/') + str(en_size) + "_" + model + "_" + target_exp
+            base_file_name = OUTPUT_DIR + '/'+ str(en_size) + "_" + model + "_" + target_exp
 
             # Determine which experiments to keep use in the archive then separate the
             # data into the archive and target data sets.
-            archive_exps = set(exps)
             archive_to_use = archive_data.loc[(archive_data["model"] == model) & (archive_data["experiment"].isin(archive_exps))]
             target_to_use = archive_data.loc[(archive_data["model"] == model) & (archive_data["experiment"] == target_exp)]
+            # remove any ensemble members that stop in 2014:
+            target_to_use = prep_target_data(target_to_use).copy()
 
             # TODO might need to add an assert function to make sure that there is actual data.
 
@@ -106,29 +135,51 @@ for en_size in ensemble_size:
             # Generate the recipes using the various tols.
             N_matches = int(1e100)
             print(".07")
-            rp_07 = stitches.make_recipe(target_data=target_to_use, archive_data=archive_to_use, N_matches=N_matches, tol=0.07)
+            rp_07 = stitches.make_recipe(target_data=target_to_use,
+                                         archive_data=archive_to_use,
+                                         N_matches=N_matches,
+                                         tol=0.07,
+                                         reproducible=True)
+            print(".075")
+            rp_075 = stitches.make_recipe(target_data=target_to_use,
+                                          archive_data=archive_to_use,
+                                          N_matches=N_matches,
+                                          tol=0.075,
+                                          reproducible=True)
             print(".1")
-            rp_1 = stitches.make_recipe(target_data=target_to_use, archive_data=archive_to_use, N_matches=N_matches, tol=0.1)
+            rp_1 = stitches.make_recipe(target_data=target_to_use,
+                                        archive_data=archive_to_use,
+                                        N_matches=N_matches,
+                                        tol=0.1,
+                                        reproducible=True)
             print(".13")
-            rp_13 = stitches.make_recipe(target_data=target_to_use, archive_data=archive_to_use, N_matches=N_matches, tol=0.13)
+            rp_13 = stitches.make_recipe(target_data=target_to_use,
+                                         archive_data=archive_to_use,
+                                         N_matches=N_matches,
+                                         tol=0.13,
+                                         reproducible=True)
 
             rp_07["tol"] = "0.07"
+            rp_075["tol"] = "0.075"
             rp_1["tol"] = "0.10"
             rp_13["tol"] = "0.13"
 
-            out = pd.concat([rp_07, rp_1, rp_13])
+            out = pd.concat([rp_07,rp_075, rp_1, rp_13])
             fname = base_file_name + "_recepie.csv"
             out.to_csv(fname)
 
             out_07 = stitches.gmat_stitching(rp_07)
+            out_075 = stitches.gmat_stitching(rp_075)
             out_1 = stitches.gmat_stitching(rp_1)
             out_13 = stitches.gmat_stitching(rp_13)
 
             out_07["tol"] = "0.07"
+            out_075["tol"] = "0.075"
             out_1["tol"] = "0.10"
             out_13["tol"] = "0.13"
 
-            out = pd.concat([out_07, out_1, out_13])
+            out = pd.concat([out_07,out_075
+                                , out_1, out_13])
             out["experiment"] = target_exp
             out["ensemble_size"] = en_size
             fname = base_file_name + "_synthetic.csv"

--- a/modules/paper1_enrich_ensemble.py
+++ b/modules/paper1_enrich_ensemble.py
@@ -130,6 +130,13 @@ for en_size in ensemble_size:
             fname = base_file_name + "_compdata.csv"
             data.to_csv(fname)
 
+            data_path = pkg_resources.resource_filename('stitches', 'data/tas-data/' + model + "_tas.csv")
+            data = pd.read_csv(data_path)
+            data = data.loc[
+                (data["experiment"] == target_exp) & (data["ensemble"].isin(target_to_use.ensemble.unique()))].copy()
+            fname = base_file_name + "_compdata_entire_target.csv"
+            data.to_csv(fname)
+
             # Generate the recipes using the various tols.
             N_matches = int(1e100)
             print(".07")

--- a/modules/tas_psl_stitching_paper1.py
+++ b/modules/tas_psl_stitching_paper1.py
@@ -10,6 +10,7 @@ import xarray as xr
 OUTPUT_DIR = pkg_resources.resource_filename('stitches', 'data')
 
 # Stitch one realization per target ensemble, match in specified tolerance.
+filter_future = True
 Nmatches = 1
 tolerance = 0.075
 # #####################################################
@@ -103,7 +104,7 @@ del(i1)
 del(i2)
 
 # #####################################################
-model_list = ["CAMS-CSM1-0", "MIROC6"]
+model_list = [ "MIROC6"]
 
 # model_list = ["ACCESS-CM2", "ACCESS-ESM1-5", "AWI-CM-1-1-MR", "CAMS-CSM1-0", "CanESM5", "CAS-ESM2-0",
 #               "CESM2", "CESM2-WACCM", "FGOALS-g3", "FIO-ESM-2-0", "GISS-E2-1-G", "GISS-E2-1-H",
@@ -165,7 +166,7 @@ for model_to_use in model_list:
                               reproducible=True)
 
     # Save the recipe
-    rp.to_csv(OUTPUT_DIR + "/tas_psl_pr/" + model_to_use + "_ssp245_rp.csv")
+    rp.to_csv(OUTPUT_DIR + "/tas_psl_pr/" + model_to_use + "_ssp245_rp.csv",index=False)
 
     # Stitch save the stitched GSATs for quality assurance:
     gsat_245 = stitches.gmat_stitching(rp)
@@ -227,7 +228,7 @@ for model_to_use in model_list:
                               reproducible=True)
 
     # Save the recipe
-    rp.to_csv(OUTPUT_DIR + "/tas_psl_pr/" + model_to_use + "_ssp370_rp.csv")
+    rp.to_csv(OUTPUT_DIR + "/tas_psl_pr/" + model_to_use + "_ssp370_rp.csv", index=False)
 
     # Stitch save the stitched GSATs for quality assurance:
     gsat_370 = stitches.gmat_stitching(rp)
@@ -286,3 +287,20 @@ for model_to_use in model_list:
                                       model_to_use+ '.csv'), index=False)
 
 # end for loop over ESMs
+
+
+# Filter generated files to future if needed
+if filter_future:
+    from pathlib import Path
+    # read in each stitched realization, subset to 2015
+    entries = Path((OUTPUT_DIR + '/tas_psl_pr/stitched/'))
+    for entry in entries.iterdir():
+        print(entry.name)
+        ds = xr.open_dataset((OUTPUT_DIR + '/tas_psl_pr/stitched/') + entry.name)
+        ds = ds.sel(time = slice('2015-01-31', '2100-12-31')).copy()
+        ds.to_netcdf((OUTPUT_DIR + '/tas_psl_pr/stitched_future/') + entry.name)
+        del(ds)
+
+
+
+

--- a/modules/tas_psl_stitching_paper1.py
+++ b/modules/tas_psl_stitching_paper1.py
@@ -96,7 +96,7 @@ data = data[data['experiment'].isin({'ssp126', 'ssp245', 'ssp370', 'ssp585',
 #     holder.append(df1[['model', 'experiment', 'n_ens']].drop_duplicates())
 # holder = pd.concat(holder).drop_duplicates().reset_index(drop=True).copy()
 
-model_list = ["CAMS-CSM1-0", "MIROC6"]
+model_list = ["CAMS-CSM1-0" "MIROC6"]
 
 # model_list = ["ACCESS-CM2", "ACCESS-ESM1-5", "AWI-CM-1-1-MR", "CAMS-CSM1-0", "CanESM5", "CAS-ESM2-0",
 #               "CESM2", "CESM2-WACCM", "FGOALS-g3", "FIO-ESM-2-0", "GISS-E2-1-G", "GISS-E2-1-H",

--- a/modules/tas_psl_stitching_paper1.py
+++ b/modules/tas_psl_stitching_paper1.py
@@ -5,6 +5,15 @@ import stitches as stitches
 import pkg_resources
 import xarray as xr
 
+# results will be written into a `tas_psl_pr` directory in the stitches package
+# `data` directory. `tas_psl_pr` has `comparison` and `stitched` subdirectories
+OUTPUT_DIR = pkg_resources.resource_filename('stitches', 'data')
+
+# Stitch one realization per target ensemble, match in specified tolerance.
+Nmatches = 1
+tolerance = 0.075
+
+
 
 # Load the archive data we want to match on.
 archive_path = pkg_resources.resource_filename('stitches', 'data/matching_archive.csv')
@@ -12,48 +21,142 @@ data = pd.read_csv(archive_path)
 data = data[data['experiment'].isin({'ssp126', 'ssp245', 'ssp370', 'ssp585',
                                          'ssp119',  'ssp534-over', 'ssp434', 'ssp460'})].copy()
 
-model_list = ["ACCESS-CM2", "ACCESS-ESM1-5", "AWI-CM-1-1-MR", "CAMS-CSM1-0", "CanESM5", "CAS-ESM2-0",
-              "CESM2", "CESM2-WACCM", "FGOALS-g3", "FIO-ESM-2-0", "GISS-E2-1-G", "GISS-E2-1-H",
-              "HadGEM3-GC31-LL", "HadGEM3-GC31-MM", "MIROC-ES2L", "MIROC6", "MPI-ESM1-2-HR",
-              "MPI-ESM1-2-LR", "MRI-ESM2-0", "NorESM2-LM", "NorESM2-LM", "UKESM1-0-LL"]
+# ##########################################################
+# We will do a run of a model with a lot of ensemble members,
+# and then a model with few.
+#
+# # Code for determining models
+# pangeo_path = pkg_resources.resource_filename('stitches', 'data/pangeo_table.csv')
+# pangeo_data = pd.read_csv(pangeo_path)
+# pangeo_data = pangeo_data[((pangeo_data['variable'] == 'tas') | (pangeo_data['variable'] == 'pr') | (pangeo_data['variable'] == 'psl'))
+#                           & ((pangeo_data['domain'] == 'Amon') ) ].copy()
+#
+# # Keep only the runs that have data for all vars X all timesteps:
+# pangeo_good_ensembles =[]
+# for name, group in pangeo_data.groupby(['model', 'experiment', 'ensemble']):
+#     df = group.drop_duplicates().copy()
+#     if len(df) == 3:
+#         pangeo_good_ensembles.append(df)
+#     del(df)
+# pangeo_good_ensembles = pd.concat(pangeo_good_ensembles)
+# pangeo_good_ensembles  = pangeo_good_ensembles[['model', 'experiment', 'ensemble']].drop_duplicates().copy()
+# pangeo_good_ensembles = pangeo_good_ensembles.reset_index(drop=True).copy()
+#
+# x = pangeo_good_ensembles.drop_duplicates().reset_index(drop=True).copy()
+# x = x[(x['experiment'] == 'ssp126') | (x['experiment'] == 'ssp585')].copy()
+# holder = []
+# grped = x.groupby(['model', 'experiment'])
+# for name, group in grped:
+#     df1 = group.drop_duplicates().copy()
+#     df1['n_ens'] = len(df1)
+#     holder.append(df1[['model', 'experiment', 'n_ens']].drop_duplicates())
+# holder = pd.concat(holder).drop_duplicates().reset_index(drop=True).copy()
+
+model_list = ["CAMS-CSM1-0", "MIROC6"]
+# ##########################################################
+# model_list = ["ACCESS-CM2", "ACCESS-ESM1-5", "AWI-CM-1-1-MR", "CAMS-CSM1-0", "CanESM5", "CAS-ESM2-0",
+#               "CESM2", "CESM2-WACCM", "FGOALS-g3", "FIO-ESM-2-0", "GISS-E2-1-G", "GISS-E2-1-H",
+#               "HadGEM3-GC31-LL", "HadGEM3-GC31-MM", "MIROC-ES2L", "MIROC6", "MPI-ESM1-2-HR",
+#               "MPI-ESM1-2-LR", "MRI-ESM2-0", "NorESM2-LM", "NorESM2-LM", "UKESM1-0-LL"]
+
+
 
 for model_to_use in model_list:
+    # Select the data to use as our archive.
+    # For this paper experiment, we remain with the bracketing scenarios:
+    archive_data = data[(data['model'] == model_to_use) &
+                        ((data['experiment'] == 'ssp126') |
+                         (data['experiment'] == 'ssp585'))].copy()
 
-     # Run for the ssp2-4.5 targets --------------------------------------------------------------
-     # Select the some data to use as the target data
-     target_data = data[data["model"] == model_to_use]
-     target_data = target_data[target_data["experiment"] == 'ssp245']
-     target_data = target_data.reset_index(drop=True)
 
-     # Select the data to use as our archive.
-     archive_data = data[(data['model'] == model_to_use) & (data['experiment'] != 'ssp245')].copy()
+    # Run for the ssp2-4.5 targets --------------------------------------------------------------
+    # Select the some data to use as the target data
+    target_data = data[data["model"] == model_to_use].copy()
+    target_data = target_data[target_data["experiment"] == 'ssp245'].copy()
+    target_data = target_data.reset_index(drop=True).copy()
 
-     # Here is an example of how to make a recipe using the make recipe function, is basically wraps
-     # all of the matching & formatting steps into a single function. Res can be set to "mon" or "day"
-     # to indicate the resolution of the stitched data. Right now day & res are both working!
-     # However we may run into issues with different types of calendars.
-     rp = stitches.make_recipe(target_data=target_data, archive_data=archive_data, res="mon", tol=0.1,
-                               non_tas_variables=["psl", "pr"], N_matches=100)
-     rp.to_csv("./tas_psl_pr/" + model_to_use + "_ssp245_rp.csv")
-     out = stitches.gridded_stitching("./tas_psl_pr/stitched", rp)
 
-     # Run for the ssp3-7.0 targets --------------------------------------------------------------
-     # Select the some data to use as the target data
-     target_data = data[data["model"] == model_to_use]
-     target_data = target_data[target_data["experiment"] == 'ssp370']
-     target_data = target_data.reset_index(drop=True)
+    # we will target  with the first 5 numerical ensemble members.
+    # Not all models start the ensemble count at 1,
+    # And not all experiments of a given model report the
+    # same realizations.
+    # select 5 ensemble realizations to
+    # look at if there are more than 5.
+    f = lambda x: x.ensemble[:x.idx]
 
-     # Select the data to use as our archive.
-     archive_data = data[(data['model'] == model_to_use) & (data['experiment'] != 'ssp370')].copy()
+    if not target_data.empty:
+        ensemble_list = pd.DataFrame({'ensemble': target_data["ensemble"].unique()})
+        ensemble_list['idx'] = ensemble_list['ensemble'].str.index('i')
+        ensemble_list['ensemble_id'] = ensemble_list.apply(f, axis=1)
+        ensemble_list['ensemble_id'] = ensemble_list['ensemble_id'].str[1:].astype(int)
+        ensemble_list = ensemble_list.sort_values('ensemble_id').copy()
+        if len(ensemble_list) > 5:
+            ensemble_keep = ensemble_list.iloc[0:5].ensemble
+        else:
+            ensemble_keep = ensemble_list.ensemble
 
-     # Here is an example of how to make a recipe using the make recipe function, is basically wraps
-     # all of the matching & formatting steps into a single function. Res can be set to "mon" or "day"
-     # to indicate the resolution of the stitched data. Right now day & res are both working!
-     # However we may run into issues with different types of calendars.
-     rp = stitches.make_recipe(target_data=target_data, archive_data=archive_data, res="mon", tol=0.1,
-                               non_tas_variables=["psl", "pr"], N_matches=100)
-     rp.to_csv("./tas_psl_pr/" + model_to_use + "_ssp370_rp.csv")
-     out = stitches.gridded_stitching("./tas_psl_pr/stitched", rp)
+        target_data = target_data[target_data['ensemble'].isin(ensemble_keep)].copy()
+        del (ensemble_keep)
+        del (ensemble_list)
+
+
+    # Here is an example of how to make a recipe using the make recipe function, is basically wraps
+    # all of the matching & formatting steps into a single function. Res can be set to "mon" or "day"
+    # to indicate the resolution of the stitched data. Right now day & res are both working!
+    # However we may run into issues with different types of calendars.
+    rp = stitches.make_recipe(target_data=target_data,
+                              archive_data=archive_data,
+                              res="mon",
+                              tol=tolerance,
+                              non_tas_variables=["psl", "pr"],
+                              N_matches=Nmatches,
+                              reproducible=True)
+    rp.to_csv(OUTPUT_DIR + "/tas_psl_pr/" + model_to_use + "_ssp245_rp.csv")
+    out = stitches.gridded_stitching((OUTPUT_DIR +"/tas_psl_pr/stitched"), rp)
+
+    # Run for the ssp3-7.0 targets --------------------------------------------------------------
+    # Select the some data to use as the target data
+    target_data = data[data["model"] == model_to_use].copy()
+    target_data = target_data[target_data["experiment"] == 'ssp370'].copy()
+    target_data = target_data.reset_index(drop=True).copy()
+
+    # we will target  with the first 5 numerical ensemble members.
+    # Not all models start the ensemble count at 1,
+    # And not all experiments of a given model report the
+    # same realizations.
+    # select 5 ensemble realizations to
+    # look at if there are more than 5.
+    f = lambda x: x.ensemble[:x.idx]
+
+    if not target_data.empty:
+        ensemble_list = pd.DataFrame({'ensemble': target_data["ensemble"].unique()})
+        ensemble_list['idx'] = ensemble_list['ensemble'].str.index('i')
+        ensemble_list['ensemble_id'] = ensemble_list.apply(f, axis=1)
+        ensemble_list['ensemble_id'] = ensemble_list['ensemble_id'].str[1:].astype(int)
+        ensemble_list = ensemble_list.sort_values('ensemble_id').copy()
+        if len(ensemble_list) > 5:
+            ensemble_keep = ensemble_list.iloc[0:5].ensemble
+        else:
+            ensemble_keep = ensemble_list.ensemble
+
+        target_data = target_data[target_data['ensemble'].isin(ensemble_keep)].copy()
+        del (ensemble_keep)
+        del (ensemble_list)
+
+    # Here is an example of how to make a recipe using the make recipe function, is basically wraps
+    # all of the matching & formatting steps into a single function. Res can be set to "mon" or "day"
+    # to indicate the resolution of the stitched data. Right now day & res are both working!
+    # However we may run into issues with different types of calendars.
+    rp = stitches.make_recipe(target_data=target_data,
+                              archive_data=archive_data,
+                              res="mon",
+                              tol=tolerance,
+                              non_tas_variables=["psl", "pr"],
+                              N_matches=Nmatches,
+                              reproducible=True)
+    rp.to_csv(OUTPUT_DIR + "/tas_psl_pr/" + model_to_use + "_ssp370_rp.csv")
+    out = stitches.gridded_stitching((OUTPUT_DIR + "/tas_psl_pr/stitched"), rp)
+
 
     # Save a copy for comparison data --------------------------------------------------------------
     # Get a copy off the pangeo table
@@ -69,8 +172,9 @@ for model_to_use in model_list:
         ds.sortby('time')
 
         info = pangeo_table[pangeo_table["zstore"] == f].copy().reset_index(drop=True)
-        fname = ("./tas_psl_pr/comparison/comparison_" + info.experiment_id[0] + "_" +
+        fname = (OUTPUT_DIR +"/tas_psl_pr/comparison/comparison_" + info.experiment_id[0] + "_" +
                  info.source_id[0] + "_" + info.member_id[0] + "_" +
                  info.variable_id[0] + ".nc")
         ds.to_netcdf(fname)
 
+# end for loop over ESMs

--- a/modules/tas_psl_stitching_paper1.py
+++ b/modules/tas_psl_stitching_paper1.py
@@ -104,7 +104,7 @@ del(i1)
 del(i2)
 
 # #####################################################
-model_list = [ "MIROC6"]
+model_list = [ "CAMS-CSM1-0", "MIROC6"]
 
 # model_list = ["ACCESS-CM2", "ACCESS-ESM1-5", "AWI-CM-1-1-MR", "CAMS-CSM1-0", "CanESM5", "CAS-ESM2-0",
 #               "CESM2", "CESM2-WACCM", "FGOALS-g3", "FIO-ESM-2-0", "GISS-E2-1-G", "GISS-E2-1-H",

--- a/modules/tas_psl_stitching_paper1.py
+++ b/modules/tas_psl_stitching_paper1.py
@@ -103,7 +103,7 @@ del(i1)
 del(i2)
 
 # #####################################################
-model_list = ["CAMS-CSM1-0","MIROC6"]
+model_list = ["CAMS-CSM1-0", "MIROC6"]
 
 # model_list = ["ACCESS-CM2", "ACCESS-ESM1-5", "AWI-CM-1-1-MR", "CAMS-CSM1-0", "CanESM5", "CAS-ESM2-0",
 #               "CESM2", "CESM2-WACCM", "FGOALS-g3", "FIO-ESM-2-0", "GISS-E2-1-G", "GISS-E2-1-H",
@@ -115,6 +115,10 @@ for model_to_use in model_list:
     archive_data = data[(data['model'] == model_to_use) &
                         ((data['experiment'] == 'ssp126') |
                          (data['experiment'] == 'ssp585'))].copy()
+
+    # save off the ensembles in the archive for CT to check from if needed
+    archive_data[['model', 'experiment', 'ensemble']].drop_duplicates().to_csv((OUTPUT_DIR + '/tas_psl_pr/archive_used_gridded_tas_psl_pr_' +
+                 model_to_use + '.csv'), index=False)
 
 
     # Run for the ssp2-4.5 targets --------------------------------------------------------------
@@ -255,11 +259,16 @@ for model_to_use in model_list:
     keep = keep.rename(columns = {'model':'source_id',
                                   'experiment': 'experiment_id',
                                   'ensemble' :'member_id'}).copy()
+    # save it off; These are the actual ensembles targeted, which is not necessarily
+    # the same as ensembles stitched (since we can run out of viable matches):
+    keep[keep['experiment_id'] != 'historical'].to_csv((OUTPUT_DIR + '/tas_psl_pr/ensembles_targeted_gridded_tas_psl_pr_' +
+                                      model_to_use+ '.csv'), index=False)
+
     # and use keep to filter the pangeo_table
     keys = list(keep.columns.values)
     i1 = pangeo_table.set_index(keys).index
     i2  = keep.set_index(keys).index
-    pangeo_table1 = pangeo_table[i1.isin(i2)].reset_index(drop=True).copy()
+    pangeo_table = pangeo_table[i1.isin(i2)].reset_index(drop=True).copy()
 
     # Save a copy of the data.
     for f in pangeo_table["zstore"]:

--- a/stitches/fx_recepie.py
+++ b/stitches/fx_recepie.py
@@ -764,6 +764,7 @@ def make_recipe(target_data, archive_data, N_matches, res="mon", tol=0.1, non_ta
     else:
         out = recipe.copy()
 
+    out = out.sort_values(by=['stitching_id', 'target_start_yr']).reset_index(drop=True).copy()
     return out
 
 

--- a/stitches/fx_recepie.py
+++ b/stitches/fx_recepie.py
@@ -170,7 +170,7 @@ def permute_stitching_recipes(N_matches, matched_data, archive, optional=None, t
         :param optional:        a previous output of this function that contains a list of already created recipes
                                 to avoid re-making (this is not implemented).
         :param testing:         Boolean True/False. Defaults to False. If True, then pd.DataFrame.sample() uses
-                                the argument random_state=stitch_ind so that the behavior can be reliably replicated
+                                the argument random_state=1 so that the behavior can be reliably replicated
                                 without setting global seeds.
 
 
@@ -670,7 +670,8 @@ def generate_gridded_recipe(messy_recipe, res='mon'):
     return out
 
 
-def make_recipe(target_data, archive_data, N_matches, res="mon", tol=0.1, non_tas_variables=None):
+def make_recipe(target_data, archive_data, N_matches, res="mon", tol=0.1, non_tas_variables=None,
+                reproducible = False):
     """ Generate a stitching recipe.
 
          :param target_data:       a pandas data frame of climate information to emulate.
@@ -679,6 +680,9 @@ def make_recipe(target_data, archive_data, N_matches, res="mon", tol=0.1, non_ta
          :param res:               str of mon or day to indicate the resolution of the stitched data
          :param tol:               float value indicating the tolerance to use in the matching process, default set to 0.1
          :param non_tas_variables: a list of variables other than tas to stitch together, when using the default set to None only tas will be stitched together.
+         :param reproducible:         Boolean True/False. Defaults to False. If True,the call to permute_stitching_recipes()
+                                                 uses the testing=True argument so that the behavior can be reliably replicated
+                                                                                 without setting global seeds.
 
          :return:                   pandas data frame of a formatted recpie
      """
@@ -734,7 +738,16 @@ def make_recipe(target_data, archive_data, N_matches, res="mon", tol=0.1, non_ta
 
     # So the permute stitiching recipe works it works when N matches is set to 1 see blow for an
     # example where the function fails to return 2 matches per target.
-    unformatted_recipe = permute_stitching_recipes(N_matches=N_matches, matched_data=match_df, archive=archive_data)
+    if reproducible:
+        unformatted_recipe = permute_stitching_recipes(N_matches=N_matches,
+                                                       matched_data=match_df,
+                                                       archive=archive_data,
+                                                       testing=True)
+    else:
+        unformatted_recipe = permute_stitching_recipes(N_matches=N_matches,
+                                                       matched_data=match_df,
+                                                       archive=archive_data,
+                                                       testing=False)
 
     # Format the recipe into the dataframe that can be used by the stitching functions.
     recipe = generate_gridded_recipe(unformatted_recipe, res=res)

--- a/stitches/fx_stitch.py
+++ b/stitches/fx_stitch.py
@@ -100,7 +100,8 @@ def get_var_info(rp, dl, fl, name):
     extracted = dl[index]
 
     attrs = data.get_ds_meta(extracted)
-    attrs["calendar"] = extracted.indexes['time'].calendar
+    if (attrs.frequency.values != "mon"):
+        attrs["calendar"] = extracted.indexes['time'].calendar
 
     return attrs
 
@@ -176,8 +177,9 @@ def internal_stitch(rp, dl, fl):
         if ((max(rp["target_end_yr"]) == 2099) & (len(times) == (len(gridded_data) - 12))):
             gridded_data = gridded_data[0:len(times), 0:, 0:].copy()
 
-        if ((var_info["calendar"][0].lower() == "noleap") & (freq == "D")):
-            times = times[~((times.month == 2) & (times.day == 29))]
+        if (freq == "D"):
+            if ((var_info["calendar"][0].lower() == "noleap") & (freq == "D")):
+                times = times[~((times.month == 2) & (times.day == 29))]
 
         assert (len(gridded_data) == len(times)), "Problem with the length of time"
 

--- a/stitches/fx_stitch.py
+++ b/stitches/fx_stitch.py
@@ -226,6 +226,8 @@ def gridded_stitching(out_dir, rp):
                             'archive_variable', 'archive_model', 'archive_ensemble', 'stitching_id',
                             'archive_start_yr', 'archive_end_yr'})
 
+    rp = rp.sort_values(by=['stitching_id', 'target_start_yr']).reset_index(drop=True).copy()
+
     # Determine which variables will be downloaded.
     variables = find_var_cols(rp)
     if not (len(variables) >= 1):

--- a/stitches/fx_stitch.py
+++ b/stitches/fx_stitch.py
@@ -333,6 +333,8 @@ def gmat_stitching(rp):
                             'archive_variable', 'archive_model', 'archive_ensemble', 'stitching_id',
                             'archive_start_yr', 'archive_end_yr', 'tas_file'})
 
+    rp = rp.sort_values(by=['stitching_id', 'target_start_yr']).reset_index(drop=True).copy()
+
     # One the assumptions of this function is that it only works with tas, so
     # we can safely add tas as the variable column.
     rp['variable'] = 'tas'


### PR DESCRIPTION
- inheriting handling the sort by time fix for gridded stitching, have it a bunch of places for safety
- update the gridded stitching experiment script (https://github.com/JGCRI/stitches/blob/acs-gridded-enriched/modules/tas_psl_stitching_paper1.py) so that it saves off a `future` subsetted version of netcdf files as well. This addition to the code is incredibly fast, the slowness is still entirely the stitching itself. not the subsetting