### PR TITLE
Update the internal package tests

### DIFF
--- a/stitches/tests/test_internal_data.py
+++ b/stitches/tests/test_internal_data.py
@@ -3,65 +3,57 @@ import pkg_resources
 import os
 import unittest
 
+from stitches.fx_util import nrow
 from stitches.fx_pangeo import fetch_pangeo_table
 
-class MyInternalData(unittest.TestCase):
+class TestInternalData(unittest.TestCase):
 
+    # This test checks the internal package data and throws an error if the
+    # internal package data needs to be updated/rerun.
+    PANGEO_TABLE = pd.read_csv(pkg_resources.resource_filename('stitches', 'data/pangeo_comparison_table.csv'))
+    MATCHING_ARCHIVE = pd.read_csv(pkg_resources.resource_filename('stitches', 'data/matching_archive.csv'))
 
-    def test_pkg_data(self):
+    # Get the most up todate pangeo catalog
+    CURRENT_DATA = fetch_pangeo_table()
 
-        # Make sure the matching data is consistent with internal tas data.
-        #
-        # Read in the archive that is used in the matching process, we are going to
-        # compare the model / experiment / ensembles / variables that exist here with
-        # must also exist in the raw tas data files.
-        path = pkg_resources.resource_filename('stitches', 'data/matching_archive.csv')
-        df = pd.read_csv(path)[["experiment", "model", "ensemble"]]
-        matching_archive = df.drop_duplicates(keep='last')
+    def test_pangeo_catalog1(self):
+        internal_fresh = self.PANGEO_TABLE.merge(self.CURRENT_DATA, how='left', indicator=True)
+        new_data = internal_fresh[internal_fresh["_merge"] == 'left_only']
+        self.assertEqual(nrow(new_data), 0, "New data available on Pangeo")
+        new_tas_data = new_data[new_data["variable_id"] == "tas"]
+        self.assertEqual(nrow(new_tas_data), 0, "New tas available on Pangeo")
 
-        # Load the model / experiment / ensembles / variables for all of the files
-        # in the stitches/data/tas directory.
+    def test_pangeo_catalog2(self):
+        fresh_internal = self.CURRENT_DATA.merge(self.PANGEO_TABLE, how='left', indicator=True)
+        data_removed = fresh_internal[fresh_internal["_merge"] != "both"]
+        self.assertEqual(nrow(data_removed), 0,
+                         "Internal pangeo catalog contains content not in current pangeo catalog")
+
+    def test_tas_files(self):
+        # Make sure that the contents of the tas files are consistent with the
+        # pangeo catalog. This test was added because there has been issues
+        # with this in the past.
+
+        # All of the tas files to import
         tas_dir = pkg_resources.resource_filename('stitches', 'data/tas-data')
         tas_files = os.listdir(tas_dir)
         tas_files = [s for s in tas_files if "csv" in s]
 
+        # Read in the tas file information
         internal_tas_list = []
         for f in tas_files:
-            dat = pd.read_csv(tas_dir + "/" + f)[['experiment', 'ensemble', 'model']].drop_duplicates(keep='last').reset_index(drop=True)
+            dat = pd.read_csv(tas_dir + "/" + f)[['experiment', 'ensemble', 'model']]\
+                .drop_duplicates(keep='last').reset_index(drop=True)
             internal_tas_list.append(dat)
         internal_tas_data = pd.concat(internal_tas_list)
 
-        # Make sure that the contents of the matching archive is consistent with all of the
-        # package tas data.
-        cond = len(matching_archive.merge(internal_tas_data)) == len(matching_archive)
-        self.assertEqual(cond, True)
+        archive_meta_info = self.MATCHING_ARCHIVE[["experiment", "model", "ensemble"]]\
+            .drop_duplicates(keep='last').reset_index(drop=True)
 
-        # Okay now the stitches pangeo table against the current table, limit the data
-        # to the experiment & ensemble data of thee files that have been included as
-        # internal tas package data.
-        exps_check = internal_tas_data["experiment"].unique()
-        ens_check = internal_tas_data["ensemble"].unique()
-
-        path = pkg_resources.resource_filename('stitches', 'data/pangeo_comparison_table.csv')
-        package_comparison = pd.read_csv(path)
-        package_comparison = package_comparison.loc[((package_comparison["experiment_id"].isin(exps_check)) &
-                                                    (package_comparison["member_id"].isin(ens_check)))]
-        current_comparison = fetch_pangeo_table()
-        current_comparison = current_comparison.loc[((current_comparison["experiment_id"].isin(exps_check)) &
-                                                    (current_comparison["member_id"].isin(ens_check)))]
-
-       # cond = package_comparison.shape <= current_comparison.shape
-       # self.assertEqual(cond, True)
-
-       # # First check for files that have were removed from the pangeo archive.
-       # cond = len(package_comparison.merge(current_comparison)) == len(package_comparison)
-       # self.assertEqual(cond, True)
-
-       # # Now check to see if files have been added to the pangeo archive.
-       # cond = len(current_comparison.merge(package_comparison)) == len(current_comparison)
-       # self.assertEqual(cond, True)
-
-        self.assertEqual(True, True)
+        archive_tas = archive_meta_info.merge(internal_tas_data, how='left', indicator=True)
+        extra_data = archive_tas[archive_tas["_merge"] != "both"]
+        self.assertEqual(nrow(extra_data), 0,
+                         "Archive data contains data not found within tas data files")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Update the internal package data test. These tests are about making sure our internal package data is consistent with the data available on pangeo & that the internal package data is self-consistent so we don't run into the issues we were running into with the 1st paper. 

I do have two questions input from @abigailsnyder and @crvernon is much needed!
