### PR TITLE
Fix language in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ To install for use, run the following:
 python -m pip install git+https://github.com/JGCRI/stitches.git
 ```
 
-To install pre-built run the following:
+To install package data that has already been pre-processed run the following:
 ```python
 import stitches
 
 stitches.install_package_data()
 ```
 
-For users that would like to generate the run the following: 
+For users who would like to generate the package data locally, run the following: 
 
 ```python
 import stitches


### PR DESCRIPTION
Addresses #77 concerning confusing language in the README.  This has now been rephrased.

JOSS review thread:
https://github.com/openjournals/joss-reviews/issues/5525